### PR TITLE
update: according the new R and vle versions

### DIFF
--- a/R/rvle.R
+++ b/R/rvle.R
@@ -186,7 +186,8 @@ rvle.setDuration <- function(rvleHandle, value)
 {
     stopifnot(is.rvle(rvleHandle))
 
-    .Call("experiment_set_duration", rvleHandle, as.real(value), PACKAGE="rvle")
+    .Call("experiment_set_duration", rvleHandle, as.numeric(value),
+                                     PACKAGE="rvle")
 
     return (invisible(NULL))
 }
@@ -218,7 +219,7 @@ rvle.setBegin <- function(rvleHandle, value)
 {
     stopifnot(is.rvle(rvleHandle))
 
-    .Call("experiment_set_begin", rvleHandle, as.real(value), PACKAGE="rvle")
+    .Call("experiment_set_begin", rvleHandle, as.numeric(value), PACKAGE="rvle")
 
     return (invisible(NULL))
 }
@@ -323,7 +324,7 @@ rvle.addRealCondition <- function(rvleHandle, condition, port, value)
     stopifnot(is.character(condition))
     stopifnot(is.character(port))
     
-    .Call("condition_add_real", rvleHandle, condition, port, as.real(value),
+    .Call("condition_add_real", rvleHandle, condition, port, as.numeric(value),
             PACKAGE="rvle")
     
     return (invisible(NULL))

--- a/src/rvle.cpp
+++ b/src/rvle.cpp
@@ -79,8 +79,9 @@ rvle_t rvle_pkg_open(const char* pkgname, const char* filename)
     vpz::Vpz*  file = 0;
 
     try {
-        Package::package().select(pkgname);
-        std::string filepath = Path::path().getPackageExpFile(filename);
+        vle::utils::Package pack(pkgname);
+        std::string filepath = pack.getExpFile(filename,
+                vle::utils::PKG_BINARY);
         file = new vpz::Vpz(filepath);
         return file;
     } catch(const std::exception& e) {
@@ -97,29 +98,16 @@ int rvle_compile_vle_output()
         //homedir is set before calling this method
         //current dir contains vle.ouput pkg
 
-        vle::utils::Package::package().refresh();
+        vle::utils::Package pack("vle.output");
 
-        Package::package().select("vle.output");
-        Package::package().configure();
-        Package::package().wait((*logfile), (*logfile));
-        if (Package::package().isSuccess()) {
-            Package::package().build();
-            Package::package().wait((*logfile), (*logfile));
-            if (Package::package().isSuccess()) {
-                Package::package().install();
-                Package::package().wait((*logfile), (*logfile));
-            }
-        }
-
-        Package::package().select("test_port");
-        Package::package().configure();
-        Package::package().wait((*logfile), (*logfile));
-        if (Package::package().isSuccess()) {
-            Package::package().build();
-            Package::package().wait((*logfile), (*logfile));
-            if (Package::package().isSuccess()) {
-                Package::package().install();
-                Package::package().wait((*logfile), (*logfile));
+        pack.configure();
+        pack.wait((*logfile), (*logfile));
+        if (pack.isSuccess()) {
+            pack.build();
+            pack.wait((*logfile), (*logfile));
+            if (pack.isSuccess()) {
+                pack.install();
+                pack.wait((*logfile), (*logfile));
             }
         }
     }  catch(const std::exception& e) {
@@ -140,15 +128,16 @@ int rvle_compile_test_port()
         //homedir is set before calling this method
         //current dir contains tert_port pkg
 
-        Package::package().select("test_port");
-        Package::package().configure();
-        Package::package().wait((*logfile), (*logfile));
-        if (Package::package().isSuccess()) {
-            Package::package().build();
-            Package::package().wait((*logfile), (*logfile));
-            if (Package::package().isSuccess()) {
-                Package::package().install();
-                Package::package().wait((*logfile), (*logfile));
+        vle::utils::Package pack("test_port");
+
+        pack.configure();
+        pack.wait((*logfile), (*logfile));
+        if (pack.isSuccess()) {
+            pack.build();
+            pack.wait((*logfile), (*logfile));
+            if (pack.isSuccess()) {
+                pack.install();
+                pack.wait((*logfile), (*logfile));
             }
         }
     }  catch(const std::exception& e) {
@@ -159,7 +148,6 @@ int rvle_compile_test_port()
     logfile->close();
     return -1;
 }
-
 
 rvle_t rvle_open(const char* filename)
 {


### PR DESCRIPTION
- R 3.0 : as.real no longer exists
- taking into account the version of vle without the Package singleton
- remove an unecessary compilation step of test_port

NOTE: modifications for R 3.0 were required to test this
